### PR TITLE
Fix: add missing image gallery theme

### DIFF
--- a/package/src/components/ImageGallery/components/ImageGrid.tsx
+++ b/package/src/components/ImageGallery/components/ImageGrid.tsx
@@ -137,7 +137,7 @@ export const ImageGrid = <
     theme: {
       colors: { white },
       imageGallery: {
-        grid: { contentContainer },
+        grid: { container, contentContainer },
       },
     },
   } = useTheme();
@@ -156,6 +156,7 @@ export const ImageGrid = <
   return (
     <BottomSheetFlatList<GridImageItem<StreamChatGenerics>>
       accessibilityLabel='Image Grid'
+      style={container}
       contentContainerStyle={[
         styles.contentContainer,
         { backgroundColor: white },

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -182,6 +182,7 @@ export type Theme = {
       rightContainer: ViewStyle;
     };
     grid: {
+      container: ViewStyle;
       contentContainer: ViewStyle;
       gridAvatar: ImageStyle;
       gridAvatarWrapper: ViewStyle;

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -686,6 +686,7 @@ export const defaultTheme: Theme = {
       rightContainer: {},
     },
     grid: {
+      container: {},
       contentContainer: {},
       gridAvatar: {},
       gridAvatarWrapper: {},


### PR DESCRIPTION
Add container theme config for BottomSheetFlatList in ImageGrid.

</div>
<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203253824-9f994b23-4716-40d1-8356-1a8ea446b720.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203254164-cdb80d8c-2a36-4199-b547-4812049a455e.png" />
            </td>
        </tr>
    </tbody>
</table>