### PR TITLE
Fix: unmatched border radius

### DIFF
--- a/package/src/components/ImageGallery/components/ImageGridHandle.tsx
+++ b/package/src/components/ImageGallery/components/ImageGridHandle.tsx
@@ -13,8 +13,8 @@ const styles = StyleSheet.create({
   },
   handle: {
     alignItems: 'center',
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
     flexDirection: 'row',
     height: 40,
     justifyContent: 'center',


### PR DESCRIPTION
Fix unmatched border radius for the image grid handle.

</div>
<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203255393-c4994f01-17df-4479-9494-b0f132b3dad2.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203255435-a193f9af-fae8-46c1-8a86-bdd459aed2f1.png" />
            </td>
        </tr>
    </tbody>
</table>